### PR TITLE
Add support for GEOGRAPHY column type in BigQuery

### DIFF
--- a/data_diff/sqeleton/abcs/database_types.py
+++ b/data_diff/sqeleton/abcs/database_types.py
@@ -157,6 +157,11 @@ class Struct(ColType):
 
 
 @dataclass
+class Geography(ColType):
+    pass
+
+
+@dataclass
 class Integer(NumericType, IKey):
     precision: int = 0
     python_type: type = int

--- a/data_diff/sqeleton/abcs/mixins.py
+++ b/data_diff/sqeleton/abcs/mixins.py
@@ -9,6 +9,7 @@ from .database_types import (
     String_UUID,
     JSON,
     Struct,
+    Geography,
 )
 from .compiler import Compilable
 
@@ -75,6 +76,9 @@ class AbstractMixin_NormalizeValue(AbstractMixin):
         """Creates an SQL expression, that serialized a typed struct into a JSON string."""
         return self.to_string(value)
 
+    def normalize_geography(self, value: str, _coltype: Geography) -> str:
+        raise NotImplementedError
+
     def normalize_value_by_type(self, value: str, coltype: ColType) -> str:
         """Creates an SQL expression, that converts 'value' to a normalized representation.
 
@@ -105,6 +109,8 @@ class AbstractMixin_NormalizeValue(AbstractMixin):
             return self.normalize_array(value, coltype)
         elif isinstance(coltype, Struct):
             return self.normalize_struct(value, coltype)
+        elif isinstance(coltype, Geography):
+            return self.normalize_geography(value, coltype)
         return self.to_string(value)
 
 

--- a/data_diff/sqeleton/databases/base.py
+++ b/data_diff/sqeleton/databases/base.py
@@ -37,6 +37,7 @@ from ..abcs.database_types import (
     DbPath,
     Boolean,
     JSON,
+    Geography,
 )
 from ..abcs.mixins import Compilable
 from ..abcs.mixins import (
@@ -262,7 +263,7 @@ class BaseDialect(AbstractDialect):
                 )
             )
 
-        elif issubclass(cls, (JSON, Array, Struct, Text, Native_UUID)):
+        elif issubclass(cls, (JSON, Array, Struct, Text, Native_UUID, Geography)):
             return cls()
 
         raise TypeError(f"Parsing {type_repr} returned an unknown type '{cls}'.")


### PR DESCRIPTION
This PR adds support for `GEOGRAPHY` type columns to `data-diff`.
The main issue is making geography values comparable, so this uses `ST_ASTEXT` so data-diff can use `IS DISTINCT FROM` to compare the values.