### PR TITLE
DATA-555: Implement in engine differ to run statistict in the database instead of pulling all data

### DIFF
--- a/data_diff/__init__.py
+++ b/data_diff/__init__.py
@@ -1,6 +1,7 @@
 from typing import Sequence, Tuple, Iterator, Optional, Union
 
 from data_diff.sqeleton.abcs import DbTime, DbPath
+from .in_enginediff_tables import InEngineJoinDiffer
 
 from .tracking import disable_tracking
 from .databases import connect
@@ -164,6 +165,17 @@ def diff_tables(
         if isinstance(materialize_to_table, str):
             materialize_to_table = table1.database.parse_table_name(eval_name_template(materialize_to_table))
         differ = JoinDiffer(
+            threaded=threaded,
+            max_threadpool_size=max_threadpool_size,
+            validate_unique_key=validate_unique_key,
+            sample_exclusive_rows=sample_exclusive_rows,
+            materialize_to_table=materialize_to_table,
+            materialize_all_rows=materialize_all_rows,
+            table_write_limit=table_write_limit,
+            skip_null_keys=skip_null_keys,
+        )
+    elif algorithm == Algorithm.INENGINEDIFF:
+        differ = InEngineJoinDiffer(
             threaded=threaded,
             max_threadpool_size=max_threadpool_size,
             validate_unique_key=validate_unique_key,

--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -12,6 +12,7 @@ import rich
 from rich.logging import RichHandler
 import click
 
+from data_diff.in_enginediff_tables import InEngineJoinDiffer
 from data_diff.sqeleton.schema import create_schema
 from data_diff.sqeleton.queries.api import current_timestamp
 

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -303,7 +303,7 @@ def _local_diff(diff_vars: TDiffVars, json_output: bool = False) -> None:
         table1,
         table2,
         threaded=True,
-        algorithm=Algorithm.JOINDIFF,
+        algorithm=Algorithm.INENGINEDIFF,
         extra_columns=extra_columns,
         where=diff_vars.where_filter,
         skip_null_keys=True,

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -28,6 +28,7 @@ class Algorithm(Enum):
     AUTO = "auto"
     JOINDIFF = "joindiff"
     HASHDIFF = "hashdiff"
+    INENGINEDIFF = "in_engine"
 
 
 DiffResult = Iterator[Tuple[str, tuple]]  # Iterator[Tuple[Literal["+", "-"], tuple]]

--- a/data_diff/in_enginediff_tables.py
+++ b/data_diff/in_enginediff_tables.py
@@ -1,0 +1,129 @@
+import logging
+from functools import partial
+
+from .joindiff_tables import JoinDiffer, bool_to_int
+from .sqeleton import this
+from .sqeleton.queries import sum_, and_
+from .sqeleton.queries.api import not_, or_
+from .sqeleton.queries.ast_classes import Cast, Code
+from .sqeleton.utils import safezip
+from .table_segment import TableSegment
+from .diff_tables import DiffResultWrapper, DiffStats, DiffResult
+from .info_tree import InfoTree, SegmentInfo
+from .thread_utils import ThreadedYielder
+
+logger = logging.getLogger("inenginediff_tables")
+
+
+class InEngineDiffResultWrapper(DiffResultWrapper):
+    def _get_stats(self, is_dbt: bool = False) -> DiffStats:
+        diff_by_sign = self.stats["diff_by_sign"]
+        table1_count = self.info_tree.info.rowcounts[1]
+        table2_count = self.info_tree.info.rowcounts[2]
+        unchanged = table1_count - diff_by_sign["-"] - diff_by_sign["!"]
+        diff_percent = 1 - unchanged / max(table1_count, table2_count)
+
+        extra_columns = self.info_tree.info.tables[0].extra_columns
+        extra_column_diffs = {k: 0 for k in sorted(extra_columns)}
+        for key in extra_column_diffs.keys():
+            extra_column_diffs[key] = self.stats["full_stats"][f"{key}_a"]
+
+        return DiffStats(diff_by_sign, table1_count, table2_count, unchanged, diff_percent, extra_column_diffs)
+
+
+class InEngineJoinDiffer(JoinDiffer):
+    def diff_tables(self, table1: TableSegment, table2: TableSegment, info_tree: InfoTree = None) -> DiffResultWrapper:
+        if info_tree is None:
+            info_tree = InfoTree(SegmentInfo([table1, table2]))
+        return InEngineDiffResultWrapper(self._diff_tables_wrapper(table1, table2, info_tree), info_tree, self.stats)
+
+    def _get_updated_cols(self, db, diff_rows, cols, is_diff_cols):
+        logger.debug("Counting differences per column")
+        is_diff_cols_counts = db.query(
+            diff_rows.select(
+                sum_(
+                    bool_to_int(
+                        and_(
+                            Cast(this[c], Code("BOOL")),
+                            not_(this.is_exclusive_a),
+                            not_(this.is_exclusive_b),
+                        )
+                    )
+                )
+                for c in is_diff_cols
+            ),
+            tuple,
+        )
+        diff_counts = {}
+        for name, count in safezip(cols, is_diff_cols_counts):
+            diff_counts[name] = diff_counts.get(name, 0) + (count or 0)
+        self.stats["full_stats"] = diff_counts
+
+    def _get_rows_summary(self, db, diff_rows, is_diff_cols):
+        logger.debug("Counting rows on differences")
+        query_results = db.query(
+            diff_rows.select(
+                sum_(bool_to_int(this.is_exclusive_a)),
+                sum_(bool_to_int(this.is_exclusive_b)),
+                sum_(
+                    bool_to_int(
+                        or_(
+                            and_(
+                                Cast(this[c], Code("BOOL")),
+                                not_(this.is_exclusive_a),
+                                not_(this.is_exclusive_b),
+                            )
+                            for c in is_diff_cols
+                        )
+                    )
+                ),
+            ),
+            tuple,
+        )
+        diff_counts = {}
+        for name, count in safezip("-+!", query_results):
+            diff_counts[name] = diff_counts.get(name, 0) + (count or 0)
+        self.stats["diff_by_sign"] = diff_counts
+
+    def _diff_segments(
+        self,
+        ti: ThreadedYielder,
+        table1: TableSegment,
+        table2: TableSegment,
+        info_tree: InfoTree,
+        max_rows: int,
+        level=0,
+        segment_index=None,
+        segment_count=None,
+    ) -> DiffResult:
+        assert table1.database is table2.database
+
+        if segment_index or table1.min_key or max_rows:
+            logger.info(
+                ". " * level + f"Diffing segment {segment_index}/{segment_count}, "
+                f"key-range: {table1.min_key}..{table2.max_key}, "
+                f"size <= {max_rows}"
+            )
+
+        db = table1.database
+        diff_rows, a_cols, b_cols, is_diff_cols, all_rows = self._create_outer_join(table1, table2)
+
+        with self._run_in_background(
+            partial(self._collect_stats, 1, table1, info_tree),
+            partial(self._collect_stats, 2, table2, info_tree),
+            partial(self._test_null_keys, table1, table2),
+            partial(self._sample_and_count_exclusive, db, diff_rows, a_cols, b_cols),
+            partial(self._count_diff_per_column, db, diff_rows, list(a_cols), is_diff_cols),
+            partial(
+                self._materialize_diff,
+                db,
+                all_rows if self.materialize_all_rows else diff_rows,
+                segment_index=segment_index,
+            )
+            if self.materialize_to_table
+            else None,
+        ):
+            assert len(a_cols) == len(b_cols)
+            self._get_updated_cols(db, diff_rows, list(a_cols), is_diff_cols)
+            self._get_rows_summary(db, diff_rows, is_diff_cols)
+            yield "done", tuple()

--- a/data_diff/sqeleton/queries/api.py
+++ b/data_diff/sqeleton/queries/api.py
@@ -90,6 +90,9 @@ def and_(*exprs: Expr):
     return BinBoolOp("AND", exprs)
 
 
+def not_(exp: Expr):
+    return UnaryOp("NOT ", exp)
+
 def sum_(expr: Expr):
     """Call SUM(expr)"""
     return Func("sum", [expr])


### PR DESCRIPTION
The current implementation of the JoinDiffer only computes part of the metrics in the DB and the rest are done by pulling all the modified rows and doing counting in python. When there are big amounts of rows updates, this causes the process to hang for long time fetching all the data.
This PR implements a new type of differ InEngineDiffer (based on the JoinDiffer one) that gets the statistics by running queries in the source database instead of pulling all the data.
