### PR TITLE
DATA-1076: Fix wrong primary key with unique tests with where

### DIFF
--- a/data_diff/dbt_config_validators.py
+++ b/data_diff/dbt_config_validators.py
@@ -15,6 +15,7 @@ class ManifestJsonConfig(BaseModel):
             schema_: Optional[str] = Field(..., alias="schema")
             tags: List[str]
             unique_key: Optional[Union[str, List[str]]]
+            where: Optional[str]
 
         class Column(BaseModel):
             meta: Dict[str, Any]
@@ -40,6 +41,7 @@ class ManifestJsonConfig(BaseModel):
         tags: List[str]
         test_metadata: Optional[TestMetadata]
         depends_on: DependsOn
+        where: Optional[str]
 
     metadata: Metadata
     nodes: Dict[str, Nodes]

--- a/data_diff/dbt_config_validators.py
+++ b/data_diff/dbt_config_validators.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Union
 from pydantic import BaseModel, Field
 
 
@@ -14,6 +14,7 @@ class ManifestJsonConfig(BaseModel):
             database: Optional[str]
             schema_: Optional[str] = Field(..., alias="schema")
             tags: List[str]
+            unique_key: Optional[Union[str, List[str]]]
 
         class Column(BaseModel):
             meta: Dict[str, Any]

--- a/data_diff/dbt_parser.py
+++ b/data_diff/dbt_parser.py
@@ -514,7 +514,7 @@ class DbtParser:
 
                 model_node = manifest.nodes[uid]
                 if node.test_metadata:
-                    if node.test_metadata.name == "unique":
+                    if node.test_metadata.name == "unique" and node.where is None and node.config.where is None:
                         column_name: str = node.test_metadata.kwargs["column_name"]
                         for col in self._parse_concat_pk_definition(column_name):
                             if model_node is None or col in model_node.columns:


### PR DESCRIPTION
There is an issue with data-diff using unique test with a `where` clause as part of the primary key, which generates wrong diff results.
This PR introduces two changes to fix that:
- `unique_key` field defined in the model config will take precedence when determining the model's primary key, and unique tests will be ignored if this is set.
- `unique` tests with a `where` clause will not be considered as part of primary key.